### PR TITLE
fixes sort by :id on chrome

### DIFF
--- a/src/app/home.cljs
+++ b/src/app/home.cljs
@@ -11,8 +11,9 @@
   (let [data-state
         (map #(assoc % :solution (get @user-data (:id %)))
              data/problems)
-        key (if (nil? @sort-by-solved) :id :solution)
-        sorted (sort-by key #(not (nil? %)) data-state)]
+        sorted (if (nil? @sort-by-solved)
+                 (sort-by :id data-state)
+                 (sort-by :solution #(not (nil? %)) data-state))]
     (if (false? @sort-by-solved) (reverse sorted) sorted)))
 
 (defn get-problem-status [id]

--- a/src/app/problem.cljs
+++ b/src/app/problem.cljs
@@ -87,7 +87,7 @@
                  :on-close modal-on-close}
       [modal-results-section @results (:tests problem) (:id problem)]
       [:div
-       [:p
+       [:p {:on-click #(reset! modal-is-open false)}
         "Next problem " 
         [:a {:href (state/href :problem/item {:id (:id next-prob)})}
          (str "#" (:id next-prob) " " (:title next-prob))]]]


### PR DESCRIPTION
The sort by id, when clicking on the "No." header, is working fine on Firefox but not on Chrome.
I jacked in and found, on Chrome it was sorting in reverse order with the `#(not (nil? %)` function. 

So I made the sorting logic more explicit now (sorry for messing it up earlier). 

Also, added an :on-click event to hide the modal when the next problem link is clicked. 