### PR TITLE
enable paren matching

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
     <meta property="twitter:image" content="">
 
     <link rel="stylesheet" href="/css/sakura-ink.css" type="text/css">
+    <link href="https://cdn.nextjournal.com/data/QmSaHZCU6U2DeNohfW2PuXDHkayw7w21uvUWL5oEqVWKwH?filename=viewer-1c61aac61ffa4da89b828d538c5e4eff188e7b56.css&content-type=text/css" rel="stylesheet">
     <script defer data-domain="4clojure.oxal.org" src="https://plausible.io/js/plausible.js"></script>
   </head>
   <body>


### PR DESCRIPTION
Thanks for giving such a nice example use of Nextjournal's Clojure-mode. I'd been meaning to try it out.

Adding this one CSS file makes the bracket matching work.