### PR TITLE
fix problem state when going to next problem

### DIFF
--- a/src/app/problem.cljs
+++ b/src/app/problem.cljs
@@ -63,35 +63,35 @@
                get-editor-value #(some-> @!editor-view .-state .-doc str)
                results (r/atom '())
                modal-is-open (r/atom false)
-               modal-on-close #(reset! modal-is-open false)
-               next-prob (some #(when (> (:id %) id) %) data/problems)
-               on-run (fn []
-                        (let [attempts (check-solution problem (get-editor-value))]
-                          (when attempts
-                            (reset! results attempts)
-                            (reset! modal-is-open true))))]
-    [:div
-     (when (:restricted problem)
-       [restricted-alert problem])
-     [:p "Write code which will fill in the above blanks:"]
-     [editor/editor @code !editor-view {:eval? true}]
-     [:button {:on-click on-run
-               :style {:margin-top "1rem"}}
-      "Run"]
-     [:p {:style {:margin-top "1rem"}}
-      [:small
-       "Alt+Enter will eval the local form in the editor box above. There are
-        lots of nifty such features and keybindings. More docs coming soon! (Try
-        playing with alt + arrows / ctrl + enter) in the meanwhile."]]
-     [modal/box {:is-open modal-is-open
-                 :on-close modal-on-close}
-      [modal-results-section @results (:tests problem) (:id problem)]
+               modal-on-close #(reset! modal-is-open false)]
+    (let [next-prob (some #(when (> (:id %) id) %) data/problems)
+          on-run (fn [] 
+                   (let [attempts (check-solution problem (get-editor-value))]
+                     (when attempts
+                       (reset! results attempts)
+                       (reset! modal-is-open true))))]
       [:div
-       [:p {:on-click #(reset! modal-is-open false)}
-        "Next problem " 
-        [:a {:href (state/href :problem/item {:id (:id next-prob)})}
-         (str "#" (:id next-prob) " " (:title next-prob))]]]
-      ]]))
+       (when (:restricted problem)
+         [restricted-alert problem])
+       [:p "Write code which will fill in the above blanks:"]
+       [editor/editor @code !editor-view {:eval? true}]
+       [:button {:on-click on-run
+                 :style {:margin-top "1rem"}}
+        "Run"]
+       [:p {:style {:margin-top "1rem"}}
+        [:small
+         "Alt+Enter will eval the local form in the editor box above. There are
+          lots of nifty such features and keybindings. More docs coming soon! (Try
+          playing with alt + arrows / ctrl + enter) in the meanwhile."]]
+       [modal/box {:is-open modal-is-open
+                   :on-close modal-on-close}
+        [modal-results-section @results (:tests problem) (:id problem)]
+        [:div
+         [:p {:on-click #(reset! modal-is-open false)}
+          "Next problem " 
+          [:a {:href (state/href :problem/item {:id (:id next-prob)})}
+           (str "#" (:id next-prob) " " (:title next-prob))]]]
+      ]])))
 
 (defn view [_]
   (fn [{:keys [path-params] :as _props}]


### PR DESCRIPTION
When advancing to the next problem on the problem page the internal problem state isn't advanced. Moving `next-prob` and `on-run` out of the `reagent/with-let` into a normal `let` fixes this.