### PR TITLE
Fix problem where > disapppears when rendering editor

### DIFF
--- a/src/app/editor.cljs
+++ b/src/app/editor.cljs
@@ -9,7 +9,6 @@
             [applied-science.js-interop :as j]
             [nextjournal.clojure-mode :as cm-clj]
             [nextjournal.clojure-mode.live-grammar :as live-grammar]
-            [nextjournal.clojure-mode.test-utils :as test-utils]
             [reagent.core :as r]
             [clojure.browser.dom :as dom]))
 
@@ -48,6 +47,13 @@
    (.of view/keymap historyKeymap)])
 
 
+(defn- make-state [extensions doc]
+  (.create EditorState
+            #js{:doc doc
+                :extensions (cond-> #js[(.. EditorState -allowMultipleSelections (of true))]
+                              extensions
+                              (j/push! extensions))}))
+
 (defn editor
   [source !view {:keys [eval?]}]
   (let
@@ -56,7 +62,7 @@
                 (when @!view (j/call @!view :destroy))
                 (when el
                   (reset! !view (new EditorView
-                                     (j/obj :state (test-utils/make-state
+                                     (j/obj :state (make-state
                                                     (cond-> #js [extensions]
                                                       eval? (.concat
                                                              #js


### PR DESCRIPTION
- We've been using `nextjournal.clojure-mode.test-utils/make-state`.
- That function uses `|` [for cursor position](https://github.com/nextjournal/clojure-mode/blob/db808194244bc14c12e578539b26123f3d6f9f90/src/nextjournal/clojure_mode/test_utils.cljs#L14-L15) and `<>` [for selection](https://github.com/nextjournal/clojure-mode/blob/db808194244bc14c12e578539b26123f3d6f9f90/src/nextjournal/clojure_mode/test_utils.cljs#L17-L21).
- Incomplete pairs of `<>` are discarded by the regular expression it uses, resulting in `->` or `->>` printed `-`.
- I thought that it is safe to skip the regex filtering  because AFAIK we don't store cursor positions nor selections.