### PR TITLE
fix: some error displaying issues

### DIFF
--- a/src/app/editor.cljs
+++ b/src/app/editor.cljs
@@ -86,7 +86,9 @@
                  :font-family "var(--code-font)"}}
         [:pre {:style {:margin-bottom "0.5rem"}}
          [:span "user=> "]
-         (try [:code (binding [*print-length* 20]
-                       (pr-str @last-result))]
+         (try [:code {:style {:white-space "pre-wrap"
+                              :word-break "break-all"}}
+               (binding [*print-length* 20]
+                       (if (string? @last-result) @last-result (pr-str @last-result)))]
               (catch :default e (str e)))]])]
     (finally (j/call @!view :destroy))))

--- a/src/app/problem.cljs
+++ b/src/app/problem.cljs
@@ -67,21 +67,21 @@
     (let [next-prob (next-problem id)
           on-run (fn []
                    (try
-                       (let [editor-value (get-editor-value)
-                             _ (reset! code editor-value)
-                             attempts (check-solution problem editor-value)]
-                         (when attempts
-                           (reset! results attempts)
-                           (reset! modal-is-open true)))
-                       (catch ExceptionInfo e
-                         (reset! error-stacktrace (-> e ex-data :stacktrace)))))]
+                     (let [editor-value (get-editor-value)
+                           _ (reset! code editor-value)
+                           attempts (check-solution problem editor-value)]
+                       (when attempts
+                         (reset! results attempts)
+                         (reset! modal-is-open true)))
+                     (catch ExceptionInfo e
+                       (reset! error-stacktrace (-> e ex-data :stacktrace)))))]
       [:div
        (when (:restricted problem)
          [restricted-alert problem])
        [:p "Write code which will fill in the above blanks:"]
 
        ;; Force resetting editor state when input source code changed
-       ;; e.g., when manually trigger run 
+       ;; e.g., when manually trigger run
        ^{:key @code} [editor/editor @code !editor-view {:eval? true}]
        [:button {:on-click on-run
                  :style {:margin-top "1rem"}}
@@ -99,7 +99,7 @@
           "Next problem "
           [:a {:href (state/href :problem/item {:id (:id next-prob)})}
            (str "#" (:id next-prob) " " (:title next-prob))]]]
-      ]])))
+        ]])))
 
 (defn view [_]
   (fn [{:keys [path-params] :as _props}]

--- a/src/app/problem.cljs
+++ b/src/app/problem.cljs
@@ -67,7 +67,9 @@
     (let [next-prob (next-problem id)
           on-run (fn []
                    (try
-                       (let [attempts (check-solution problem (get-editor-value))]
+                       (let [editor-value (get-editor-value)
+                             _ (reset! code editor-value)
+                             attempts (check-solution problem editor-value)]
                          (when attempts
                            (reset! results attempts)
                            (reset! modal-is-open true)))
@@ -77,7 +79,10 @@
        (when (:restricted problem)
          [restricted-alert problem])
        [:p "Write code which will fill in the above blanks:"]
-       [editor/editor @code !editor-view {:eval? true}]
+
+       ;; Force resetting editor state when input source code changed
+       ;; e.g., when manually trigger run 
+       ^{:key @code} [editor/editor @code !editor-view {:eval? true}]
        [:button {:on-click on-run
                  :style {:margin-top "1rem"}}
         "Run"]


### PR DESCRIPTION
- update error displaying under the code mirror
- show the error when clicked "run"

Old:
<img width="696" alt="image" src="https://user-images.githubusercontent.com/584378/160550295-208c99fc-d024-41c4-afdb-f8440eeb5744.png">

New:
<img width="707" alt="image" src="https://user-images.githubusercontent.com/584378/160550312-d27d31ed-8858-4671-936f-48e884a3189a.png">

Also, trigger code evaluation when clicked run to show the errors. Previously if there are any errors in the code and the user did not eval in place (alt-enter), there will be no error displaying and confused users (me)