### PR TITLE
feat: remove bullet points from problems

### DIFF
--- a/src/app/problem.cljs
+++ b/src/app/problem.cljs
@@ -111,7 +111,7 @@
        [:div {:style {:margin-top "0.5rem" :margin-bottom "2rem"}}
         [:b "Difficulty: "] difficulty]
        [:p description]
-       [:ul
+       [:ul {:style {:list-style "none" :padding 0}}
         (doall
          (for [[i test] (map-indexed vector tests)]
            ^{:key i}


### PR DESCRIPTION
I thought the bullet points looked kind of weird the way they were, so here's a suggestion.

Old:
![old-4clojure](https://user-images.githubusercontent.com/11855478/178462812-36bc77e5-5f1f-41bf-a0a1-d87419ad018e.png)


New:
![new-4clojure](https://user-images.githubusercontent.com/11855478/178462832-f7b0f6d5-b8d5-4e01-957f-133cc722643d.png)



