### PR TITLE
fix: horizontal overflow from banner

### DIFF
--- a/src/app/core.cljs
+++ b/src/app/core.cljs
@@ -9,7 +9,7 @@
                  :left 0
                  :width "100%"
                  :text-align "center"
-                 :padding "0.5rem"}}
+                 :padding "0.5rem 0"}}
    [:small
     "Solutions archive browsable from each problem page 🎉 Huge thanks to Alan!!"]])
 


### PR DESCRIPTION
Fixes a minor annoyance where the padding from the banner was creating a horizontal scrollbar across the site:

Before:
<img width="951" alt="Screenshot 2022-12-03 at 12 44 16" src="https://user-images.githubusercontent.com/19330576/205456163-002d4afb-837b-486c-add5-987c99dbb06c.png">

After:
<img width="951" alt="Screenshot 2022-12-03 at 12 45 35" src="https://user-images.githubusercontent.com/19330576/205456167-06e2f351-3778-4933-b526-eb4817395fff.png">

