### PR TITLE
Error handling and exception result

### DIFF
--- a/src/app/sci.cljs
+++ b/src/app/sci.cljs
@@ -14,9 +14,9 @@
              :namespaces {'clojure.core {'format goog.string/format}}}))
 
 (defn eval-string [source]
-  (try (sci/eval-string* context source)
+  (try {::result (sci/eval-string* context source)}
        (catch :default e
-         (with-out-str (error-handler source e)))))
+         {::error-str (with-out-str (error-handler source e))})))
 
 (j/defn eval-at-cursor [on-result ^:js {:keys [state]}]
   (some->> (eval-region/cursor-node-string state)


### PR DESCRIPTION
Evaluator's output will be this: 
```
(defn eval-string [source]
  (try {::result (sci/eval-string* context source)}
       (catch :default e
         {::error-str (with-out-str (error-handler source e))})))
```

Also I also made it so that it would show that error string in the log.
This is how it handles `[]` input in problem 38:
![image](https://user-images.githubusercontent.com/1641263/223979983-07999ee6-f0c6-4153-b3da-8a4c87361669.png)
