### PR TITLE
Display error and evaluation result together

### DIFF
--- a/src/app/editor.cljs
+++ b/src/app/editor.cljs
@@ -64,15 +64,18 @@
 
 (defn show-error [last-result test-evaluation-error-str]
   (if-let [result-output (::sci/result last-result)]
-    (binding [*print-length* 20]
-      (if test-evaluation-error-str
-        [:span
-         (pr-str result-output)
-         [:br]
-         [:br]
-         test-evaluation-error-str]
-        (pr-str result-output)))
+    [:span "user=> "
+     (binding [*print-length* 20]
+       (pr-str result-output))
+     (when test-evaluation-error-str
+       [:span
+        [:br]
+        [:br]
+        "test=> "
+        [:br]
+        test-evaluation-error-str])]
     [:span
+     "user=> "
      [:br]
      (::sci/error-str last-result)]))
 
@@ -108,7 +111,6 @@
                  :color "#333333"
                  :font-family "var(--code-font)"}}
         [:pre {:style {:margin-bottom "0.5rem"}}
-         [:span "user=> "]
          (try [:code {:style {:white-space "pre-wrap"
                               :word-break "break-all"}}
                [show-error @last-result test-evaluation-error-str]]

--- a/src/app/editor.cljs
+++ b/src/app/editor.cljs
@@ -63,19 +63,19 @@
                              (j/push! extensions))}))
 
 (defn show-error [last-result test-evaluation-error-str]
-  (if-let [result-output (::sci/result last-result)]
+  (if (contains? last-result ::sci/result)
     [:span "user=> "
      (binding [*print-length* 20]
-       (pr-str result-output))
+       (pr-str (::sci/result last-result)))
      (when test-evaluation-error-str
        [:span
         [:br]
         [:br]
-        "test=> "
+        "test=>"
         [:br]
         test-evaluation-error-str])]
     [:span
-     "user=> "
+     "user=>"
      [:br]
      (::sci/error-str last-result)]))
 


### PR DESCRIPTION
Show both evaluation result and test error string when tests crash but the expression doesn't:
![image](https://user-images.githubusercontent.com/1641263/224099415-25dc0afb-73dd-416a-8d16-3da808f50a49.png)


Show only expression result when there is no crash in tests (failure is not a crash):
 
![image](https://user-images.githubusercontent.com/1641263/224099230-e59c6ac9-0daa-48d5-81b3-40b04d8cb83c.png)


Not addressed -- reevaluate tests upon load. Only the expression itself will be reevaluated:
![image](https://user-images.githubusercontent.com/1641263/224099688-339e506d-9986-4dbe-90f7-81f8f7ec3ff8.png)


Not addressed -- not sure if I should change `user=>` string into two `user=>` strings.