### PR TITLE
add custom version of doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /public/js/
 /.shadow-cljs/
 /.cpcache

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://twitter.com/borkdude/status/1412117420173561861
 Original thread that explains why 4clojure is shutting down:
 https://groups.google.com/g/clojure/c/ZWmDEzvn-Js
 
-> Now that 4clojure is shutting down (thanks for all the years of hosting it!),
+> Now that 4clojure is shutting down (thanks for all the year of hosting it!),
 > perhaps it's time to consider some alternatives. - borkdude
 
 @borkdude suggested this in his tweet:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://twitter.com/borkdude/status/1412117420173561861
 Original thread that explains why 4clojure is shutting down:
 https://groups.google.com/g/clojure/c/ZWmDEzvn-Js
 
-> Now that 4clojure is shutting down (thanks for all the year of hosting it!),
+> Now that 4clojure is shutting down (thanks for all the years of hosting it!),
 > perhaps it's time to consider some alternatives. - borkdude
 
 @borkdude suggested this in his tweet:

--- a/src/app/problem.cljs
+++ b/src/app/problem.cljs
@@ -155,7 +155,8 @@
         [:small
          "Alt+Enter will eval the local form in the editor box above. There are
           lots of nifty such features and keybindings. More docs coming soon! (Try
-          playing with alt + arrows / ctrl + enter) in the meanwhile."]]
+          playing with alt + arrows / ctrl + enter) in the meanwhile.
+          For documentation try e.g. (doc map)."]]
        [modal/box {:is-open success-modal-is-open
                    :on-close success-modal-on-close}
         [:h4 (str "Congratulations on solving problem " "#" id "!")]

--- a/src/app/sci.cljs
+++ b/src/app/sci.cljs
@@ -8,10 +8,18 @@
             [sci.core :as sci]
             [sci.impl.evaluator]))
 
+(def doc-str-src "
+(in-ns 'user)
+(defmacro doc [sym]
+  `(str \"\n\" (with-out-str (clojure.repl/doc ~sym))))")
+
 (defonce context
-  (sci/init {:classes {'js goog/global
-                       :allow :all}
-             :namespaces {'clojure.core {'format goog.string/format}}}))
+  (doto
+   (sci/init {:classes {'js goog/global
+                        :allow :all}
+              :namespaces {'clojure.core {'format goog.string/format}}})
+   (sci/eval-string* doc-str-src)))
+
 
 (defn eval-string [source]
   (try {::result (sci/eval-string* context source)}

--- a/src/app/sci.cljs
+++ b/src/app/sci.cljs
@@ -9,7 +9,6 @@
             [sci.impl.evaluator]))
 
 (def doc-str-src "
-(in-ns 'user)
 (defmacro doc [sym]
   `(str \"\n\" (with-out-str (clojure.repl/doc ~sym))))")
 


### PR DESCRIPTION
The `sci` interpreter includes `clojure.repl/doc` but it's not imported into ns `user` and needs to be modified slightly.  We add it by evaluating custom source when we create the interpreter.  Also added a small note in the footer explaining usage.  Feel free to modify this PR or advise if you want it done differently.