### PR TITLE
Import export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can deploy your own instance via GitHub Actions:
 - [x] scrape problem difficulty (can perhaps also get ranks data?)
 - [ ] better alerts (modals?)
 - [x] show user which problems they have solved
-- [ ] import /export data of the user in a .edn file
+- [x] import /export data of the user in a .edn file
 - [ ] github actions auto deployment
 - [ ] create a new section of problems "community powered questions"
 - [ ] add new community problems directly via github

--- a/src/app/core.cljs
+++ b/src/app/core.cljs
@@ -1,5 +1,6 @@
 (ns app.core
   (:require [app.routes :as routes]
+            [app.state :as state]
             [reagent.dom :as rdom]
             [reitit.frontend.easy :as rfe]))
 
@@ -23,6 +24,8 @@
           :data-reitit-handle-click false} "home"]
      " | "
      [:a {:href "https://github.com/oxalorg/4ever-clojure"} "github"]
+     " | "
+     [:a {:on-click #(do (.preventDefault %) (state/export-user-data)) :href "#"} "Export data"]
      " | "
      "Built with ❤ by "
      [:a {:href "https://twitter.com/oxalorg"} "@oxalorg"]

--- a/src/app/core.cljs
+++ b/src/app/core.cljs
@@ -25,6 +25,8 @@
      " | "
      [:a {:href "https://github.com/oxalorg/4ever-clojure"} "github"]
      " | "
+     [:a {:on-click #(do (.preventDefault %) (state/import-user-data)) :href "#"} "Import data"]
+     " | "
      [:a {:on-click #(do (.preventDefault %) (state/export-user-data)) :href "#"} "Export data"]
      " | "
      "Built with ❤ by "

--- a/src/app/core.cljs
+++ b/src/app/core.cljs
@@ -25,9 +25,9 @@
      " | "
      [:a {:href "https://github.com/oxalorg/4ever-clojure"} "github"]
      " | "
-     [:a {:on-click #(do (.preventDefault %) (state/import-user-data)) :href "#"} "Import data"]
+     [:a {:on-click #(do (.preventDefault %) (state/import-user-data)) :href "#"} "import data"]
      " | "
-     [:a {:on-click #(do (.preventDefault %) (state/export-user-data)) :href "#"} "Export data"]
+     [:a {:on-click #(do (.preventDefault %) (state/export-user-data)) :href "#"} "export data"]
      " | "
      "Built with ❤ by "
      [:a {:href "https://twitter.com/oxalorg"} "@oxalorg"]

--- a/src/app/state.cljs
+++ b/src/app/state.cljs
@@ -1,6 +1,7 @@
 (ns app.state
   (:require [alandipert.storage-atom :as lstore]
             [cljs.reader :refer [read-string]]
+            [cljs.spec.alpha :as spec]
             [reagent.core :as r]
             [reitit.frontend.easy :as rfe]))
 
@@ -22,6 +23,15 @@
   (lstore/local-storage (r/atom {})
                         :4ever-clojure))
 
+;; E.g. {1 {:code "true", :passed 1, :failed 0}, 19 {:code "(comp first reverse)", :passed 3, :failed 0}}
+(spec/def ::code string?)
+(spec/def ::passed number?)
+(spec/def ::failed number?)
+(spec/def ::solution
+  (spec/keys :req-un [::code ::passed ::failed]))
+(spec/def ::solutions
+  (spec/map-of number? ::solution))
+
 (defn new-raw-html-el
   [tag attrs]
   (js/Object.assign
@@ -30,14 +40,7 @@
 
 (defn validate-solution-data
   [data]
-  (when
-   (and
-    (map? data)
-    (every? number? (keys data))
-    (every? string? (:code data))
-    (every? number? (:passed data))
-    (every? number? (:failed data)))
-    data))
+  (when (spec/valid? ::solutions data) data))
 
 (defn import-user-data
   "Import user data from a .edn file"

--- a/src/app/state.cljs
+++ b/src/app/state.cljs
@@ -1,7 +1,6 @@
 (ns app.state
   (:require [alandipert.storage-atom :as lstore]
             [cljs.reader :refer [read-string]]
-            [cljs.spec.alpha :as spec]
             [reagent.core :as r]
             [reitit.frontend.easy :as rfe]))
 
@@ -23,14 +22,6 @@
   (lstore/local-storage (r/atom {})
                         :4ever-clojure))
 
-;; E.g. {1 {:code "true", :passed 1, :failed 0}, 19 {:code "(comp first reverse)", :passed 3, :failed 0}}
-(spec/def ::code string?)
-(spec/def ::passed number?)
-(spec/def ::failed number?)
-(spec/def ::solution
-  (spec/keys :req-un [::code ::passed ::failed]))
-(spec/def ::solutions
-  (spec/map-of number? ::solution))
 
 (defn new-raw-html-el
   [tag attrs]
@@ -38,9 +29,22 @@
    (js/document.createElement tag)
    (clj->js attrs)))
 
+;; E.g. {1 {:code "true", :passed 1, :failed 0}, 19 {:code "(comp first reverse)", :passed 3, :failed 0}}
 (defn validate-solution-data
+  "Returns the data if valid. Throws an exception otherwise."
   [data]
-  (when (spec/valid? ::solutions data) data))
+  (if
+   (and
+    (map? data)
+    (every?
+     (fn [[id {:keys [code passed failed]}]]
+       (and
+        (number? id)
+        (string? code)
+        (number? passed)
+        (number? failed))) data))
+    data
+    (throw (js/Error. "Invalid data format"))))
 
 (defn import-user-data
   "Import user data from a .edn file"
@@ -52,11 +56,11 @@
                           reader (new js/FileReader)]
                       (set!
                        (.-onload reader)
-                       #(if-let [result (-> (.-result reader)
-                                            (read-string)
-                                            (validate-solution-data))]
-                          (reset! (r/cursor db [:solutions]) result)
-                          (js/alert "Invalid data format")))
+                       #(try (->> (.-result reader)
+                                  (read-string)
+                                  (validate-solution-data)
+                                  (reset! (r/cursor db [:solutions])))
+                             (catch :default e (js/alert (str "Invalid data: " (.-message e))))))
                       (set! (.-onerror reader) #(js/alert "Error reading file"))
                       (. reader readAsText data)))]
     (. upload addEventListener "change" on-upload)

--- a/src/app/state.cljs
+++ b/src/app/state.cljs
@@ -1,5 +1,6 @@
 (ns app.state
   (:require [alandipert.storage-atom :as lstore]
+            [cljs.reader :refer [read-string]]
             [reagent.core :as r]
             [reitit.frontend.easy :as rfe]))
 
@@ -26,6 +27,37 @@
   (js/Object.assign
    (js/document.createElement tag)
    (clj->js attrs)))
+
+(defn validate-solution-data
+  [data]
+  (when
+   (and
+    (map? data)
+    (every? number? (keys data))
+    (every? string? (:code data))
+    (every? number? (:passed data))
+    (every? number? (:failed data)))
+    data))
+
+(defn import-user-data
+  "Import user data from a .edn file"
+  []
+  (let [id "upload-input"
+        upload (new-raw-html-el "input" {:id id :type "file" :accept ".edn"})
+        on-upload (fn []
+                    (let [data (first (.-files upload))
+                          reader (new js/FileReader)]
+                      (set!
+                       (.-onload reader)
+                       #(if-let [result (-> (.-result reader)
+                                            (read-string)
+                                            (validate-solution-data))]
+                          (reset! (r/cursor db [:solutions]) result)
+                          (js/alert "Invalid data format")))
+                      (set! (.-onerror reader) #(js/alert "Error reading file"))
+                      (. reader readAsText data)))]
+    (. upload addEventListener "change" on-upload)
+    (.click upload)))
 
 (defn export-user-data
   "Get the user's solutions from local storage, and save them to a file."

--- a/src/app/state.cljs
+++ b/src/app/state.cljs
@@ -17,6 +17,24 @@
   {:solutions {}
    :sort-by-solved nil})
 
-(defonce db 
+(defonce db
   (lstore/local-storage (r/atom {})
                         :4ever-clojure))
+
+(defn new-raw-html-el
+  [tag attrs]
+  (js/Object.assign
+   (js/document.createElement tag)
+   (clj->js attrs)))
+
+(defn export-user-data
+  "Get the user's solutions from local storage, and save them to a file."
+  []
+  ;; https://stackoverflow.com/a/79383186/21908056 :)
+  (let [filename "4ever-clojure.edn"
+        content (@db :solutions)
+        file (new js/Blob [content] {"type" "text/plain"})
+        link (js/URL.createObjectURL file)
+        export (new-raw-html-el "a" {:href link :download filename})]
+    (.click export)
+    (. js/URL revokeObjectURL link)))


### PR DESCRIPTION
Allow users to export their solutions to a .edn file, and import their existing solutions.
Validates imported files so as to not corrupt user's existing data if they try to upload a bad file.

The header now looks like as below :)

<img width="693" height="109" alt="Screenshot 2026-08-08 at 10 42 26 pm" src="https://github.com/user-attachments/assets/25cd306a-13e0-403b-9523-f859dc6434d5" />
